### PR TITLE
🐛 Fix dangling cache value issue, add auto expiry of ids, implement autoheal

### DIFF
--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/validator.docker-compose.yml
+++ b/node-stack/validator/validator.docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - ip2location_data:/app/ip2location_data
     networks:
       - tpn_network
+    labels:
+      autoheal: true
 
   postgres:
     container_name: postgres
@@ -67,6 +69,18 @@ services:
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=3600
       - WATCHTOWER_TIMEOUT=60s
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  autoheal:
+    container_name: tpn_validator_autoheal
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=autoheal # use service label autoheal: true to add
+      - AUTOHEAL_INTERVAL=60s
+      - AUTOHEAL_START_PERIOD=600s # See Dockerfile
+      - CURL_TIMEOUT=60s
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT=60s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
Did 3 things:

- [ ] Fix issue where some failure modes would cause saturation of the subnet cache in the fix code deployed last week
- [ ] Added auto expiry of 2 min to interface ids just to be safe in case of function crashes that are ungraceful
- [ ] Added an autoheal monitor, this restarts the container is the container is unhealthy, we should not need this now but it will add a grace factor to future issues